### PR TITLE
8.0 partner relations v8api rewind

### DIFF
--- a/partner_relations/data/demo.xml
+++ b/partner_relations/data/demo.xml
@@ -12,7 +12,7 @@
             <field name="name_inverse">is competitor of</field>
             <field name="contact_type_left">c</field>
             <field name="contact_type_right">c</field>
-            <field name="symmetric" eval="True" />
+            <field name="is_symmetric" eval="True" />
         </record>
         <record id="rel_type_has_worked_for" model="res.partner.relation.type">
             <field name="name">works for</field>

--- a/partner_relations/i18n/nl.po
+++ b/partner_relations/i18n/nl.po
@@ -425,7 +425,7 @@ msgid "Starting date"
 msgstr "Datum ingang"
 
 #. module: partner_relations
-#: field:res.partner.relation.type,symmetric:0
+#: field:res.partner.relation.type,is_symmetric:0
 msgid "Symmetric"
 msgstr "Symmetrisch"
 
@@ -453,7 +453,7 @@ msgid "This relation can be set up with the same partner left and right"
 msgstr "Deze connectie kan een relatie met zichzelf verbinden"
 
 #. module: partner_relations
-#: help:res.partner.relation.type,symmetric:0
+#: help:res.partner.relation.type,is_symmetric:0
 msgid "This relation is the same from right to left as from left to right"
 msgstr ""
 "Deze connectie is van rechts naar links hetzelfde als van links naar rechts"

--- a/partner_relations/i18n/nl.po
+++ b/partner_relations/i18n/nl.po
@@ -9,8 +9,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: partner-contact (8.0)\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-24 23:32+0000\n"
-"PO-Revision-Date: 2016-08-25 13:54+0200\n"
+"POT-Creation-Date: 2016-09-02 12:39+0000\n"
+"PO-Revision-Date: 2016-09-02 15:03+0200\n"
 "Last-Translator: OCA Transbot <transbot@odoo-community.org>\n"
 "Language-Team: Dutch (http://www.transifex.com/oca/OCA-partner-contact-8-0/"
 "language/nl/)\n"
@@ -22,7 +22,7 @@ msgstr ""
 "X-Generator: Gtranslator 2.91.6\n"
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_all.py:169
+#: code:addons/partner_relations/models/res_partner_relation_all.py:178
 #, python-format
 msgid "%s partner incompatible with relation type."
 msgstr "%s relatie is onverenigbaar met gekozen connectietype."
@@ -64,10 +64,12 @@ msgid "All relations with current partner"
 msgstr "Alle connecties vanuit de huidige relatie"
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_type.py:55
+#: code:addons/partner_relations/models/res_partner_relation_type.py:13
+#: selection:res.partner.relation.type,handle_invalid_onchange:0
 #, python-format
-msgid "Company"
-msgstr "Bedrijf"
+msgid "Allow existing relations that do not fit changed conditions"
+msgstr ""
+"Sta bestaande connecties toe die niet voldoen aan de gewijzigde criteria"
 
 #. module: partner_relations
 #: field:res.partner.relation,create_uid:0
@@ -92,6 +94,13 @@ msgid "Current record's partner type"
 msgstr "Type van de huidige relatie"
 
 #. module: partner_relations
+#: code:addons/partner_relations/models/res_partner_relation_type.py:17
+#: selection:res.partner.relation.type,handle_invalid_onchange:0
+#, python-format
+msgid "Delete relations that do not fit changed conditions"
+msgstr "Verwijder connecties die niet voldoen aan de gewijzigde condities"
+
+#. module: partner_relations
 #: field:res.partner.relation,right_partner_id:0
 msgid "Destination Partner"
 msgstr "Doel relatie"
@@ -105,14 +114,30 @@ msgid "Display Name"
 msgstr "Te tonen naam"
 
 #. module: partner_relations
+#: code:addons/partner_relations/models/res_partner_relation_type.py:11
+#: selection:res.partner.relation.type,handle_invalid_onchange:0
+#, python-format
+msgid "Do not allow change that will result in invalid relations"
+msgstr "Sta geen wijziging toe die zal resulteren in ongeldige connecties"
+
+#. module: partner_relations
+#: code:addons/partner_relations/models/res_partner_relation_type.py:15
+#: selection:res.partner.relation.type,handle_invalid_onchange:0
+#, python-format
+msgid "End relations per today, if they do not fit changed conditions"
+msgstr ""
+"Beëindig wijzigingen per vandaag indien ze niet voldoen aan de gewijzigde "
+"condities"
+
+#. module: partner_relations
 #: field:res.partner.relation,date_end:0
 #: field:res.partner.relation.all,date_end:0
 msgid "Ending date"
 msgstr "Einddatum"
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_all.py:175
-#: code:addons/partner_relations/models/res_partner_relation_all.py:250
+#: code:addons/partner_relations/models/res_partner_relation_all.py:184
+#: code:addons/partner_relations/models/res_partner_relation_all.py:259
 #, python-format
 msgid "Error!"
 msgstr "Fout!"
@@ -163,6 +188,11 @@ msgstr "ID"
 #: view:res.partner.relation.all:partner_relations.search_res_partner_relation_all
 msgid "Include past records"
 msgstr "Inclusief beëindigde connecties"
+
+#. module: partner_relations
+#: field:res.partner.relation.type,handle_invalid_onchange:0
+msgid "Invalid relation handling"
+msgstr "Afhandeling van ongeldige connecties"
 
 #. module: partner_relations
 #: field:res.partner.relation.type,name_inverse:0
@@ -218,7 +248,7 @@ msgstr "Categorie linkerrelatie"
 #. module: partner_relations
 #: selection:res.partner.relation.all,record_type:0
 msgid "Left partner to right partner"
-msgstr "Van linkernaar rechterrelatie"
+msgstr "Van linker naar rechterrelatie"
 
 #. module: partner_relations
 #: field:res.partner.relation.type,contact_type_left:0
@@ -242,13 +272,13 @@ msgid "Name"
 msgstr "Naam"
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_all.py:172
+#: code:addons/partner_relations/models/res_partner_relation_all.py:181
 #, python-format
 msgid "No %s partner available for relation type."
 msgstr "Geen %s relatie beschikbaar voor dit connectietype."
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_all.py:247
+#: code:addons/partner_relations/models/res_partner_relation_all.py:256
 #, python-format
 msgid "No relation type available for selected partners."
 msgstr "Geen connectietype beschikbaar voor verbinden van deze relaties."
@@ -258,6 +288,12 @@ msgstr "Geen connectietype beschikbaar voor verbinden van deze relaties."
 #: field:res.partner.relation.all,this_partner_id:0
 msgid "One Partner"
 msgstr "De ene relatie"
+
+#. module: partner_relations
+#: code:addons/partner_relations/models/res_partner_relation_type.py:82
+#, python-format
+msgid "Organisation"
+msgstr "Organisatie"
 
 #. module: partner_relations
 #: view:res.partner.relation.all:partner_relations.search_res_partner_relation_all
@@ -279,7 +315,7 @@ msgstr "Type andere relatie"
 #: model:ir.model,name:partner_relations.model_res_partner
 #: field:res.partner.relation.all,any_partner_id:0
 msgid "Partner"
-msgstr "relatie"
+msgstr "Relatie"
 
 #. module: partner_relations
 #: model:ir.model,name:partner_relations.model_res_partner_relation_type
@@ -303,19 +339,13 @@ msgid "Partner relation"
 msgstr "Connectie"
 
 #. module: partner_relations
-#: model:ir.model,name:partner_relations.model_res_partner_relation_wizard
-#: model:ir.model,name:partner_relations.model_res_partner_relationi_wizard
-msgid "Partner relation wizard"
-msgstr "Connectie wizard"
-
-#. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation.py:107
+#: code:addons/partner_relations/models/res_partner_relation.py:115
 #, python-format
 msgid "Partners cannot have a relation with themselves."
 msgstr "Relaties kunnen geen connectie met zichzelf hebben"
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_type.py:56
+#: code:addons/partner_relations/models/res_partner_relation_type.py:83
 #, python-format
 msgid "Person"
 msgstr "Persoon"
@@ -337,6 +367,7 @@ msgstr "Connecties met een datum in het verleden zijn inactief"
 
 #. module: partner_relations
 #: field:res.partner.relation.type,allow_self:0
+#: field:res.partner.relation.type.selection,allow_self:0
 msgid "Reflexive"
 msgstr "Wederkerig"
 
@@ -356,7 +387,7 @@ msgid "Relation Type"
 msgstr "Type connectie"
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_all.py:243
+#: code:addons/partner_relations/models/res_partner_relation_all.py:252
 #, python-format
 msgid "Relation type incompatible with selected partner(s)."
 msgstr "Type connectie komt niet overeen met geselecteerde relatie(s)."
@@ -426,23 +457,40 @@ msgstr "Datum ingang"
 
 #. module: partner_relations
 #: field:res.partner.relation.type,is_symmetric:0
+#: field:res.partner.relation.type.selection,is_symmetric:0
 msgid "Symmetric"
 msgstr "Symmetrisch"
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation.py:93
+#: code:addons/partner_relations/models/res_partner_relation.py:101
+#, fuzzy, python-format
+msgid "The %s partner does not have category %s."
+msgstr "De %s relatie is niet geldig voor dit type connectie."
+
+#. module: partner_relations
+#: code:addons/partner_relations/models/res_partner_relation.py:95
 #, python-format
 msgid "The %s partner is not applicable for this relation type."
 msgstr "De %s relatie is niet geldig voor dit type connectie."
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation.py:60
+#: code:addons/partner_relations/models/res_partner_relation.py:61
 #, python-format
 msgid "The starting date cannot be after the ending date."
 msgstr "De ingangsdatum kan niet na de einddatum liggen."
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation.py:144
+#: code:addons/partner_relations/models/res_partner_relation_type.py:168
+#, python-format
+msgid ""
+"There are already relations not satisfying the conditions for partner type "
+"or category."
+msgstr ""
+"Er zijn al connecties die niet voldoen aan de criteria voor type relatie of "
+"categorie."
+
+#. module: partner_relations
+#: code:addons/partner_relations/models/res_partner_relation.py:154
 #, python-format
 msgid "There is already a similar relation with overlapping dates"
 msgstr "Er is al een gelijkaardige connectie met overlappende geldigheid"
@@ -465,20 +513,37 @@ msgid "Type"
 msgstr "Type"
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner.py:69
-#: code:addons/partner_relations/models/res_partner.py:107
+#: code:addons/partner_relations/models/res_partner.py:80
+#: code:addons/partner_relations/models/res_partner.py:121
 #, python-format
 msgid "Unsupported search operator \"%s\""
 msgstr "Zoek operator \"%s\" wordt niet ondersteund "
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_all.py:212
+#: help:res.partner.relation.type,handle_invalid_onchange:0
+msgid ""
+"When adding relations criteria like partner type and category are checked.\n"
+"However when you change the criteria, there might be relations that do not "
+"fit the new criteria.\n"
+"Specify how this situation should be handled."
+msgstr ""
+"Bij het aanmaken van connecties vinden controles plaats op type en categorie "
+"van de relatie.\n"
+"Echter, wanneer u de criteria verandert, dan kunnen er al connecties bestaan "
+"die daar niet aan voldoen.\n"
+"Geef aan hoe zo'n situatie moet worden afgehandeld. "
+
+#. module: partner_relations
+#: code:addons/partner_relations/models/res_partner_relation_all.py:221
 #, python-format
 msgid "other"
 msgstr "andere"
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_all.py:206
+#: code:addons/partner_relations/models/res_partner_relation_all.py:215
 #, python-format
 msgid "this"
 msgstr "deze"
+
+#~ msgid "Company"
+#~ msgstr "Bedrijf"

--- a/partner_relations/i18n/partner_relations.pot
+++ b/partner_relations/i18n/partner_relations.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2016-08-24 23:32+0000\n"
-"PO-Revision-Date: 2016-08-24 23:32+0000\n"
+"POT-Creation-Date: 2016-09-02 12:39+0000\n"
+"PO-Revision-Date: 2016-09-02 12:39+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,7 +16,7 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_all.py:169
+#: code:addons/partner_relations/models/res_partner_relation_all.py:178
 #, python-format
 msgid "%s partner incompatible with relation type."
 msgstr ""
@@ -52,9 +52,10 @@ msgid "All relations with current partner"
 msgstr ""
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_type.py:55
+#: code:addons/partner_relations/models/res_partner_relation_type.py:13
+#: selection:res.partner.relation.type,handle_invalid_onchange:0
 #, python-format
-msgid "Company"
+msgid "Allow existing relations that do not fit changed conditions"
 msgstr ""
 
 #. module: partner_relations
@@ -80,6 +81,13 @@ msgid "Current record's partner type"
 msgstr ""
 
 #. module: partner_relations
+#: code:addons/partner_relations/models/res_partner_relation_type.py:17
+#: selection:res.partner.relation.type,handle_invalid_onchange:0
+#, python-format
+msgid "Delete relations that do not fit changed conditions"
+msgstr ""
+
+#. module: partner_relations
 #: field:res.partner.relation,right_partner_id:0
 msgid "Destination Partner"
 msgstr ""
@@ -93,14 +101,28 @@ msgid "Display Name"
 msgstr ""
 
 #. module: partner_relations
+#: code:addons/partner_relations/models/res_partner_relation_type.py:11
+#: selection:res.partner.relation.type,handle_invalid_onchange:0
+#, python-format
+msgid "Do not allow change that will result in invalid relations"
+msgstr ""
+
+#. module: partner_relations
+#: code:addons/partner_relations/models/res_partner_relation_type.py:15
+#: selection:res.partner.relation.type,handle_invalid_onchange:0
+#, python-format
+msgid "End relations per today, if they do not fit changed conditions"
+msgstr ""
+
+#. module: partner_relations
 #: field:res.partner.relation,date_end:0
 #: field:res.partner.relation.all,date_end:0
 msgid "Ending date"
 msgstr ""
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_all.py:175
-#: code:addons/partner_relations/models/res_partner_relation_all.py:250
+#: code:addons/partner_relations/models/res_partner_relation_all.py:184
+#: code:addons/partner_relations/models/res_partner_relation_all.py:259
 #, python-format
 msgid "Error!"
 msgstr ""
@@ -151,6 +173,11 @@ msgstr ""
 #. module: partner_relations
 #: view:res.partner.relation.all:partner_relations.search_res_partner_relation_all
 msgid "Include past records"
+msgstr ""
+
+#. module: partner_relations
+#: field:res.partner.relation.type,handle_invalid_onchange:0
+msgid "Invalid relation handling"
 msgstr ""
 
 #. module: partner_relations
@@ -231,13 +258,13 @@ msgid "Name"
 msgstr ""
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_all.py:172
+#: code:addons/partner_relations/models/res_partner_relation_all.py:181
 #, python-format
 msgid "No %s partner available for relation type."
 msgstr ""
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_all.py:247
+#: code:addons/partner_relations/models/res_partner_relation_all.py:256
 #, python-format
 msgid "No relation type available for selected partners."
 msgstr ""
@@ -246,6 +273,12 @@ msgstr ""
 #: view:res.partner.relation.all:partner_relations.search_res_partner_relation_all
 #: field:res.partner.relation.all,this_partner_id:0
 msgid "One Partner"
+msgstr ""
+
+#. module: partner_relations
+#: code:addons/partner_relations/models/res_partner_relation_type.py:82
+#, python-format
+msgid "Organisation"
 msgstr ""
 
 #. module: partner_relations
@@ -292,19 +325,13 @@ msgid "Partner relation"
 msgstr ""
 
 #. module: partner_relations
-#: model:ir.model,name:partner_relations.model_res_partner_relation_wizard
-#: model:ir.model,name:partner_relations.model_res_partner_relationi_wizard
-msgid "Partner relation wizard"
-msgstr ""
-
-#. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation.py:107
+#: code:addons/partner_relations/models/res_partner_relation.py:115
 #, python-format
 msgid "Partners cannot have a relation with themselves."
 msgstr ""
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_type.py:56
+#: code:addons/partner_relations/models/res_partner_relation_type.py:83
 #, python-format
 msgid "Person"
 msgstr ""
@@ -326,6 +353,7 @@ msgstr ""
 
 #. module: partner_relations
 #: field:res.partner.relation.type,allow_self:0
+#: field:res.partner.relation.type.selection,allow_self:0
 msgid "Reflexive"
 msgstr ""
 
@@ -345,7 +373,7 @@ msgid "Relation Type"
 msgstr ""
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_all.py:243
+#: code:addons/partner_relations/models/res_partner_relation_all.py:252
 #, python-format
 msgid "Relation type incompatible with selected partner(s)."
 msgstr ""
@@ -415,23 +443,36 @@ msgstr ""
 
 #. module: partner_relations
 #: field:res.partner.relation.type,is_symmetric:0
+#: field:res.partner.relation.type.selection,is_symmetric:0
 msgid "Symmetric"
 msgstr ""
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation.py:93
+#: code:addons/partner_relations/models/res_partner_relation.py:101
+#, python-format
+msgid "The %s partner does not have category %s."
+msgstr ""
+
+#. module: partner_relations
+#: code:addons/partner_relations/models/res_partner_relation.py:95
 #, python-format
 msgid "The %s partner is not applicable for this relation type."
 msgstr ""
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation.py:60
+#: code:addons/partner_relations/models/res_partner_relation.py:61
 #, python-format
 msgid "The starting date cannot be after the ending date."
 msgstr ""
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation.py:144
+#: code:addons/partner_relations/models/res_partner_relation_type.py:168
+#, python-format
+msgid "There are already relations not satisfying the conditions for partner type or category."
+msgstr ""
+
+#. module: partner_relations
+#: code:addons/partner_relations/models/res_partner_relation.py:154
 #, python-format
 msgid "There is already a similar relation with overlapping dates"
 msgstr ""
@@ -453,20 +494,27 @@ msgid "Type"
 msgstr ""
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner.py:69
-#: code:addons/partner_relations/models/res_partner.py:107
+#: code:addons/partner_relations/models/res_partner.py:80
+#: code:addons/partner_relations/models/res_partner.py:121
 #, python-format
 msgid "Unsupported search operator \"%s\""
 msgstr ""
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_all.py:212
+#: help:res.partner.relation.type,handle_invalid_onchange:0
+msgid "When adding relations criteria like partner type and category are checked.\n"
+"However when you change the criteria, there might be relations that do not fit the new criteria.\n"
+"Specify how this situation should be handled."
+msgstr ""
+
+#. module: partner_relations
+#: code:addons/partner_relations/models/res_partner_relation_all.py:221
 #, python-format
 msgid "other"
 msgstr ""
 
 #. module: partner_relations
-#: code:addons/partner_relations/models/res_partner_relation_all.py:206
+#: code:addons/partner_relations/models/res_partner_relation_all.py:215
 #, python-format
 msgid "this"
 msgstr ""

--- a/partner_relations/i18n/partner_relations.pot
+++ b/partner_relations/i18n/partner_relations.pot
@@ -414,7 +414,7 @@ msgid "Starting date"
 msgstr ""
 
 #. module: partner_relations
-#: field:res.partner.relation.type,symmetric:0
+#: field:res.partner.relation.type,is_symmetric:0
 msgid "Symmetric"
 msgstr ""
 
@@ -442,7 +442,7 @@ msgid "This relation can be set up with the same partner left and right"
 msgstr ""
 
 #. module: partner_relations
-#: help:res.partner.relation.type,symmetric:0
+#: help:res.partner.relation.type,is_symmetric:0
 msgid "This relation is the same from right to left as from left to right"
 msgstr ""
 

--- a/partner_relations/models/res_partner_relation_all.py
+++ b/partner_relations/models/res_partner_relation_all.py
@@ -108,7 +108,7 @@ CREATE OR REPLACE VIEW %(table)s AS
         rel.date_end,
         rel.date_end IS NULL OR rel.date_end >= current_date,
         CASE
-            WHEN typ."symmetric" THEN rel.type_id * %(padding)s
+            WHEN typ.is_symmetric THEN rel.type_id * %(padding)s
             ELSE rel.type_id * %(padding)s + 1
         END
         %(additional_view_fields)s

--- a/partner_relations/models/res_partner_relation_type.py
+++ b/partner_relations/models/res_partner_relation_type.py
@@ -186,7 +186,3 @@ class ResPartnerRelationType(models.Model):
         """Handle existing relations if conditions change."""
         self.check_existing(vals)
         return super(ResPartnerRelationType, self).write(vals)
-        vals = self._correct_vals(vals)
-        for rec in self:
-            rec.relation_id.write(vals)
-        return True

--- a/partner_relations/models/res_partner_relation_type.py
+++ b/partner_relations/models/res_partner_relation_type.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+# -*/ codine: utf-8 -*-
 # © 2013-2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 """Define the type of relations that can exist between partners."""
@@ -166,7 +166,7 @@ class ResPartnerRelationType(models.Model):
                 if handling == 'restrict':
                     raise ValidationError(
                         _('There are already relations not satisfying the'
-                          'conditions for partner type or category.')
+                          ' conditions for partner type or category.')
                     )
                 elif handling == 'delete':
                     invalid_relations.unlink()

--- a/partner_relations/models/res_partner_relation_type.py
+++ b/partner_relations/models/res_partner_relation_type.py
@@ -43,8 +43,9 @@ class ResPartnerRelationType(models.Model):
         'right',
         default=False,
     )
-    symmetric = fields.Boolean(
+    is_symmetric = fields.Boolean(
         string='Symmetric',
+        old_name='symmetric',
         help="This relation is the same from right to left as from left to"
              " right",
         default=False,
@@ -59,10 +60,10 @@ class ResPartnerRelationType(models.Model):
             ('p', _('Person')),
         ]
 
-    @api.onchange('symmetric')
-    def _onchange_symmetric(self):
+    @api.onchange('is_symmetric')
+    def onchange_is_symmetric(self):
         """Set right side to left side if symmetric."""
-        if self.symmetric:
+        if self.is_symmetric:
             self.update({
                 'name_inverse': self.name,
                 'contact_type_right': self.contact_type_left,

--- a/partner_relations/models/res_partner_relation_type.py
+++ b/partner_relations/models/res_partner_relation_type.py
@@ -1,4 +1,4 @@
-# -*/ codine: utf-8 -*-
+# -*- coding: utf-8 -*-
 # © 2013-2016 Therp BV <http://therp.nl>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 """Define the type of relations that can exist between partners."""

--- a/partner_relations/models/res_partner_relation_type.py
+++ b/partner_relations/models/res_partner_relation_type.py
@@ -3,6 +3,19 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 """Define the type of relations that can exist between partners."""
 from openerp import _, api, fields, models
+from openerp.exceptions import ValidationError
+
+
+HANDLE_INVALID_ONCHANGE = [
+    ('restrict',
+     _('Do not allow change that will result in invalid relations')),
+    ('ignore',
+     _('Allow existing relations that do not fit changed conditions')),
+    ('end',
+     _('End relations per today, if they do not fit changed conditions')),
+    ('delete',
+     _('Delete relations that do not fit changed conditions')),
+]
 
 
 class ResPartnerRelationType(models.Model):
@@ -45,10 +58,20 @@ class ResPartnerRelationType(models.Model):
     )
     is_symmetric = fields.Boolean(
         string='Symmetric',
-        old_name='symmetric',
         help="This relation is the same from right to left as from left to"
              " right",
         default=False,
+    )
+    handle_invalid_onchange = fields.Selection(
+        selection=HANDLE_INVALID_ONCHANGE,
+        string='Invalid relation handling',
+        required=True,
+        default='restrict',
+        help="When adding relations criteria like partner type and category"
+             " are checked.\n"
+             "However when you change the criteria, there might be relations"
+             " that do not fit the new criteria.\n"
+             "Specify how this situation should be handled.",
     )
 
     @api.model
@@ -69,3 +92,101 @@ class ResPartnerRelationType(models.Model):
                 'contact_type_right': self.contact_type_left,
                 'partner_category_right': self.partner_category_left,
             })
+
+    @api.multi
+    def check_existing(self, vals):
+        """Check wether records exist that do not fit new criteria."""
+        relation_model = self.env['res.partner.relation']
+        for rec in self:
+            handling = (
+                'handle_invalid_onchange' in vals and
+                vals['handle_invalid_onchange'] or
+                self.handle_invalid_onchange
+            )
+            if handling == 'ignore':
+                continue
+            # only look at relations for this type
+            invalid_domain = [
+                ('type_id', '=', rec.id),
+            ]
+            contact_type_left = (
+                'contact_type_left' in vals and vals['contact_type_left'] or
+                False
+            )
+            if contact_type_left == 'c':
+                # Valid records are companies:
+                invalid_domain.append(
+                    ('left_partner_id.is_company', '=', False)
+                )
+            if contact_type_left == 'p':
+                # Valid records are persons:
+                invalid_domain.append(
+                    ('left_partner_id.is_company', '=', True)
+                )
+            contact_type_right = (
+                'contact_type_right' in vals and vals['contact_type_right'] or
+                False
+            )
+            if contact_type_right == 'c':
+                # Valid records are companies:
+                invalid_domain.append(
+                    ('right_partner_id.is_company', '=', False)
+                )
+            if contact_type_right == 'p':
+                # Valid records are persons:
+                invalid_domain.append(
+                    ('right_partner_id.is_company', '=', True)
+                )
+            partner_category_left = (
+                'partner_category_left' in vals and
+                vals['partner_category_left'] or
+                False
+            )
+            if partner_category_left:
+                # records that do not have the specified category are invalid:
+                invalid_domain.append(
+                    ('left_partner_id.category_id', 'not in',
+                     partner_category_left)
+                )
+            partner_category_right = (
+                'partner_category_right' in vals and
+                vals['partner_category_right'] or
+                False
+            )
+            if partner_category_right:
+                # records that do not have the specified category are invalid:
+                invalid_domain.append(
+                    ('right_partner_id.category_id', 'not in',
+                     partner_category_right)
+                )
+            invalid_relations = relation_model.with_context(
+                active_test=False
+            ).search(invalid_domain)
+            if invalid_relations:
+                if handling == 'restrict':
+                    raise ValidationError(
+                        _('There are already relations not satisfying the'
+                          'conditions for partner type or category.')
+                    )
+                elif handling == 'delete':
+                    invalid_relations.unlink()
+                else:
+                    # Delete future records, end other ones, ignore relations
+                    # already ended:
+                    cutoff_date = fields.Date.today()
+                    for relation in invalid_relations:
+                        if relation.date_start >= cutoff_date:
+                            relation.unlink()
+                        elif (not relation.date_end or
+                                relation.date_end > cutoff_date):
+                            relation.write({'date_end': cutoff_date})
+
+    @api.multi
+    def write(self, vals):
+        """Handle existing relations if conditions change."""
+        self.check_existing(vals)
+        return super(ResPartnerRelationType, self).write(vals)
+        vals = self._correct_vals(vals)
+        for rec in self:
+            rec.relation_id.write(vals)
+        return True

--- a/partner_relations/models/res_partner_relation_type_selection.py
+++ b/partner_relations/models/res_partner_relation_type_selection.py
@@ -61,7 +61,7 @@ class ResPartnerRelationTypeSelection(models.Model):
     allow_self = fields.Boolean(
         string='Reflexive',
     )
-    symmetric = fields.Boolean(
+    is_symmetric = fields.Boolean(
         string='Symmetric',
     )
 
@@ -79,7 +79,7 @@ class ResPartnerRelationTypeSelection(models.Model):
                 partner_category_left AS partner_category_this,
                 partner_category_right AS partner_category_other,
                 allow_self,
-                "symmetric"
+                is_symmetric
             FROM %(underlying_table)s
             UNION SELECT
                 id * %(padding)s + 1,
@@ -91,9 +91,9 @@ class ResPartnerRelationTypeSelection(models.Model):
                 partner_category_right,
                 partner_category_left,
                 allow_self,
-                "symmetric"
+                is_symmetric
              FROM %(underlying_table)s
-             WHERE not "symmetric"
+             WHERE not is_symmetric
             """,
             {
                 'table': AsIs(self._table),

--- a/partner_relations/views/res_partner_relation_type.xml
+++ b/partner_relations/views/res_partner_relation_type.xml
@@ -41,6 +41,7 @@
                         <group name="properties" string="Properties">
                             <field name="allow_self" />
                             <field name="is_symmetric" />
+                            <field name="handle_invalid_onchange" />
                         </group>
                     </sheet>
                 </form>

--- a/partner_relations/views/res_partner_relation_type.xml
+++ b/partner_relations/views/res_partner_relation_type.xml
@@ -9,7 +9,7 @@
                     <field name="contact_type_left" />
                     <field name="contact_type_right" />
                     <field name="allow_self" />
-                    <field name="symmetric" />
+                    <field name="is_symmetric" />
                 </tree>
             </field>
         </record>
@@ -31,7 +31,7 @@
                             <group
                                 string="Right side of relation"
                                 name="right"
-                                attrs="{'invisible': [('symmetric', '=', True)]}"
+                                attrs="{'invisible': [('is_symmetric', '=', True)]}"
                                 >
                                 <field name="name_inverse" />
                                 <field name="contact_type_right" />
@@ -40,7 +40,7 @@
                         </group>
                         <group name="properties" string="Properties">
                             <field name="allow_self" />
-                            <field name="symmetric" />
+                            <field name="is_symmetric" />
                         </group>
                     </sheet>
                 </form>


### PR DESCRIPTION
Some more changes.

There was a problem caused by ' symmetric'  being a SQL reserved word. For some reason this caused Odoo to insert NULL values by default instead of False. And this caused the inverse selection types not to show up in the view. Anyway avoided this by renaming symmetric to is_symmetric.

Then there was the issue of changing the conditions on relation types after adding relations. This probably will make existing relations invalid. Added a way for the user to specify how to handle this situation.

Also added a lot more tests. This should hopefully increase coverage instead of decreasing it.
